### PR TITLE
5.4.10 - integration-rede-for-woocommerce(AJustes no fluxo de geração do 3DS)

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -10,7 +10,7 @@ env:
   PLUGIN_NAME: woo-rede
   DIR_NAME: woo-rede
   PHP_VERSION: "7.4"
-  DEPLOY_TAG: "5.4.9"
+  DEPLOY_TAG: "5.4.10"
 
 jobs:
   release-build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ env:
   PLUGIN_NAME: woo-rede
   DIR_NAME: woo-rede
   PHP_VERSION: "7.4"
-  DEPLOY_TAG: "5.4.9"
+  DEPLOY_TAG: "5.4.10"
 
 jobs:
   release-build:

--- a/.github/workflows/wordpressRelease.yml
+++ b/.github/workflows/wordpressRelease.yml
@@ -6,7 +6,7 @@ on:
 env:
   PLUGIN_NAME: woo-rede
   PHP_VERSION: "7.4"
-  DEPLOY_TAG: "5.4.9"
+  DEPLOY_TAG: "5.4.10"
 
 jobs:
   deploy-to-wp:

--- a/.reasonix/skills/prepare-release.md
+++ b/.reasonix/skills/prepare-release.md
@@ -1,0 +1,112 @@
+---
+name: prepare-release
+description: Prepara release do woo-rede: atualiza versão em README.txt, CHANGELOG.md, cabeçalho PHP, constante VERSION e workflows .yml baseado no git log
+---
+
+# prepare-release (woo-rede)
+
+Atualiza **todos** os arquivos que contêm o número de versão para uma nova release do plugin "Integration Rede Itaú for WooCommerce".
+
+## Parâmetros (via `arguments`)
+
+O usuário pode passar os valores diretamente: `"version=5.4.10 tested_up=7.1 php=8.2 highlights=..."`. Se algum valor faltar, pergunte.
+
+- **version** — nova versão (Stable tag)
+- **tested_up** — versão do WP testada (Tested up to)
+- **php** — versão mínima do PHP (Requires PHP)
+- **highlights** — resumo da versão (opcional, usa git log se vazio)
+
+## Fluxo de execução
+
+### 1. Coletar valores
+
+Se não recebidos via arguments, pergunte um por um. Detecte a versão atual:
+
+```
+grep -E "Stable tag:" README.txt
+grep -E "define\('INTEGRATION_REDE_FOR_WOOCOMMERCE_VERSION'" lkn-integration-rede-for-woocommerce-file.php
+```
+
+Data de hoje: use `date +%Y-%m-%d` (ou API de tempo se o shell não estiver disponível).
+
+### 2. Capturar git log
+
+```bash
+LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null)
+if [ -z "$LAST_TAG" ]; then
+    git log -n 10 --oneline
+else
+    git log ${LAST_TAG}..HEAD --oneline
+fi
+```
+
+### 3. Atualizar TODOS os arquivos com versão
+
+A versão aparece em **7 arquivos** (o `README.txt` tem 3 locais distintos).
+
+#### 3a. `README.txt`
+
+- `Stable tag:` → nova versão (linha ~8)
+- `Tested up to:` e `Requires PHP:` se alterados
+- Adicionar entrada no `## Changelog` (topo da seção), **sempre em inglês**, usando data `YYYY-MM-DD`. Deixar **uma linha em branco** entre a nova entrada e a anterior:
+  ```
+  ### VERSION - YYYY-MM-DD
+  * Item baseado nos commits
+
+  ### VERSAO_ANTERIOR - YYYY-MM-DD
+  ```
+- ⚠️ O `README.txt` tem **DUAS** listas de changelog: `## Changelog` **e** `## Upgrade Notice`. Adicionar a MESMA entrada nas duas.
+
+#### 3b. `CHANGELOG.md`
+
+- Adicionar entrada no topo do arquivo, **em português**, usando data `DD/MM/YY`:
+  ```
+  # VERSION - DD/MM/YY
+  * Item baseado nos commits
+  ```
+
+#### 3c. `integration-rede-for-woocommerce.php` (raiz)
+
+- `* Version:           X` (cabeçalho do plugin, linha ~18)
+- `Requires PHP:` / `Requires at least:` se alterados
+
+#### 3d. `lkn-integration-rede-for-woocommerce-file.php`
+
+- `define('INTEGRATION_REDE_FOR_WOOCOMMERCE_VERSION', 'X')` (linha ~20)
+
+#### 3e. `.github/workflows/main.yml`
+
+- `DEPLOY_TAG: "X"`
+
+#### 3f. `.github/workflows/dev-release.yml`
+
+- `DEPLOY_TAG: "X"`
+
+#### 3g. `.github/workflows/wordpressRelease.yml`
+
+- `DEPLOY_TAG: "X"` (o `VERSION: ${{ env.DEPLOY_TAG }}` é derivado — não editar)
+
+## NÃO alterar (pegadinhas do woo-rede)
+
+- `Includes/LknIntegrationRedeForWoocommerce.php:133` → `$this->version = '1.0.0'` é **fallback de bootstrap** (nunca é bumpado; a versão real vem da constante `INTEGRATION_REDE_FOR_WOOCOMMERCE_VERSION`).
+- `Includes/LknIntegrationRedeForWoocommerceWcRede.php:12` → `public const VERSION = '3.1.2'` é **versão de migração de DB** (`wc_rede_version`), não a versão do plugin.
+- `package.json` → `version` é do dev container, não do plugin.
+- `Admin/LknIntegrationRedeForWoocommerceAdmin.php:144` usa a constante, sem literal — não editar.
+
+## 4. Validação final
+
+Grep com a versão **antiga**:
+
+```
+grep -rn "VERSAO_ANTIGA" --include="*.php" --include="*.md" --include="*.txt" --include="*.yml" .
+```
+
+Esperado: `CHANGELOG.md` e `README.txt` ainda contêm a versão antiga **apenas** nas entradas antigas do changelog. Qualquer outro arquivo retornando a versão antiga é **erro**.
+
+Grep com a versão **nova**:
+
+```
+grep -rn "NOVA_VERSAO" --include="*.php" --include="*.md" --include="*.txt" --include="*.yml" .
+```
+
+Deve retornar: `README.txt` (3x: stable tag + changelog + upgrade notice), `CHANGELOG.md` (1x), `.php` raiz (1x), constante (1x), 3 workflows (3x) = **9 matches** no mínimo.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 5.4.10 - 26/08/2026
+* Ajuste: Cancelamento ou timeout no desafio 3D Secure agora recusa a transação (onFailure sempre "decline").
+* Ajuste: Cartões não registrados no 3DS (returnCode 204) são reenviados sem 3DS quando "Continuar sem 3DS" está habilitado.
+* Correção: Falha na validação de segurança do webhook 3DS agora redireciona ao checkout e registra nota no pedido.
+
 # 5.4.9 - 17/08/2026
 * Ajuste: Validação da rota de webhook.
 

--- a/Includes/LknIntegrationRedeForWoocommerceWcEndpoint.php
+++ b/Includes/LknIntegrationRedeForWoocommerceWcEndpoint.php
@@ -785,8 +785,11 @@ final class LknIntegrationRedeForWoocommerceWcEndpoint
 
         // VALIDAÇÃO DE SEGURANÇA: Verifica autenticidade da requisição
         if (!$this->validate_webhook_security($order, $parameters, 'success')) {
-            $order->add_order_note('[' . $order->get_payment_method() . '] ' . __('Security validation failed for 3DS webhook', 'woo-rede'));
-            return new WP_Error('security_validation_failed', __('Security validation failed', 'woo-rede'), array('status' => 403));
+            $order->add_order_note('[' . $order->get_payment_method() . '] ' . __('Security validation failed for 3DS success webhook', 'woo-rede'));
+            // Redireciona de volta ao checkout em vez de deixar o cliente preso na URL do webhook
+            $redirect_url = add_query_arg('3ds_error', '1', wc_get_checkout_url());
+            wp_safe_redirect($redirect_url);
+            exit;
         }
 
         try {
@@ -840,7 +843,11 @@ final class LknIntegrationRedeForWoocommerceWcEndpoint
 
         // VALIDAÇÃO DE SEGURANÇA: Verifica autenticidade da requisição
         if (!$this->validate_webhook_security($order, $parameters, 'failure')) {
-            return new WP_Error('security_validation_failed', __('Security validation failed', 'woo-rede'), array('status' => 403));
+            $order->add_order_note('[' . $order->get_payment_method() . '] ' . __('Security validation failed for 3DS failure webhook', 'woo-rede'));
+            // Redireciona de volta ao checkout em vez de deixar o cliente preso na URL do webhook
+            $redirect_url = add_query_arg('3ds_error', '1', wc_get_checkout_url());
+            wp_safe_redirect($redirect_url);
+            exit;
         }
 
         // Salvar metadados da transação usando helper (mesmo para falhas)

--- a/Includes/LknIntegrationRedeForWoocommerceWcRedeDebit.php
+++ b/Includes/LknIntegrationRedeForWoocommerceWcRedeDebit.php
@@ -254,7 +254,7 @@ final class LknIntegrationRedeForWoocommerceWcRedeDebit extends LknIntegrationRe
     /**
      * Processa transação de débito/crédito
      */
-    private function process_debit_and_credit_transaction_v2($reference, $order_total, $cardData, $order_id, $order = null, $order_currency = 'BRL', $creditExpiry = '')
+    private function process_debit_and_credit_transaction_v2($reference, $order_total, $cardData, $order_id, $order = null, $order_currency = 'BRL', $creditExpiry = '', $skip_3ds = false)
     {
         $access_token = $this->get_oauth_token($order_id);
         
@@ -294,14 +294,15 @@ final class LknIntegrationRedeForWoocommerceWcRedeDebit extends LknIntegrationRe
         }
         
         // Add 3D Secure configuration if enabled (para débito e crédito)
-        if ($this->enable_3ds) {
+        if ($this->enable_3ds && ! $skip_3ds) {
             
-            // Determina o comportamento de fallback baseado no tipo de cartão
-            $fallback_behavior = ($card_type === 'debit') ? 'decline' : $this->threeds_fallback_behavior;
+            // onFailure SEMPRE 'decline': cancelamento/timeout no desafio 3DS recusam a transação.
+            // A opção "Continuar sem 3DS" (3ds_fallback_behavior) afeta SOMENTE o caso
+            // "cartão não registrado no 3DS" (returnCode 204), tratado com reenvio sem 3DS abaixo.
             
             $body['threeDSecure'] = array(
                 'embedded' => true, // Integração direta na página (true) ou redirecionamento (false)
-                'onFailure' => $fallback_behavior, // Para débito: sempre 'decline'. Para crédito: configurável
+                'onFailure' => 'decline', // Recusa se o cliente cancelar ou o desafio falhar/timeout
                 'device' => array(
                     'colorDepth' => 24, // Profundidade de cores do monitor. Aceita: 1, 4, 8, 15, 16, 24, 32, 48
                     'deviceType3ds' => 'BROWSER', // Tipo de dispositivo. Aceita: 'BROWSER', 'SDK'
@@ -391,6 +392,26 @@ final class LknIntegrationRedeForWoocommerceWcRedeDebit extends LknIntegrationRe
             $response_data['return_http'] = $response_code;
         } else {
             $response_data = array('return_http' => $response_code);
+        }
+
+        // ===== Fallback "Continuar sem 3DS" para cartões NÃO registrados no 3DS (returnCode 204) =====
+        // Diferente de cancelamento/timeout (recusados via onFailure=decline), o cartão não registrado
+        // no 3DS pode seguir como transação comum se o lojista habilitou "Continuar sem 3DS".
+        if (($response_data['returnCode'] ?? '') === '204' && $this->threeds_fallback_behavior === 'continue' && ! $skip_3ds) {
+            if ($order) {
+                $order->add_order_note('[' . $this->id . '] ' . __('Card not enrolled in 3D Secure. Retrying transaction without 3DS (fallback "continue without 3DS").', 'woo-rede'));
+            }
+            // Reenvia a transação SEM o bloco threeDSecure para autorizar como transação comum
+            return $this->process_debit_and_credit_transaction_v2(
+                $reference,
+                $order_total,
+                $cardData,
+                $order_id,
+                $order,
+                $order_currency,
+                $creditExpiry,
+                true
+            );
         }
 
         if ($response_code !== 200 && $response_code !== 201) {
@@ -1060,15 +1081,15 @@ final class LknIntegrationRedeForWoocommerceWcRedeDebit extends LknIntegrationRe
                 'title' => '3DS Comportamento Alternativo',
                 'type' => 'select',
                 'class' => 'wc-enhanced-select',
-                'description' => 'IMPORTANTE: Para cartões de débito, a autenticação 3DS é OBRIGATÓRIA e mais segura. Caso ainda sim deseje por mais flexibilidade, pode habilitar “Continuar” para proseguir com o pagamento mesmo em caso de falha do 3DS.',
-                'desc_tip' => 'Define se o pagamento prossegue ou é recusado quando a autenticação 3DS falha.',
+                'description' => 'Quando o cartão NÃO está registrado no 3DS (returnCode 204), escolha “Continuar sem 3DS” para autorizar a transação mesmo sem autenticação. Cancelamento ou timeout no desafio 3DS são SEMPRE recusados.',
+                'desc_tip' => 'Aplica-se apenas a cartões não registrados no 3DS. Cancelar/timeout do desafio recusa a transação.',
                 'default' => 'decline',
                 'options' => array(
                     'decline' => 'Recusar transação (Opção recomendada)',
                     'continue' => 'Continuar sem 3DS',
                 ),
                 'custom_attributes' => array(
-                    'data-title-description' => 'CONFORMIDADE REGULATÓRIA: Para cartões de débito, o 3DS é obrigatório. Por padrão a opção vem marcada como “Recusar”, caso habilite “Continuar”, o pagamento irá proseguir com os dados preenchidos do cliente.'
+                    'data-title-description' => 'Cartão não registrado no 3DS: “Continuar” autoriza sem 3DS. Cancelamento/timeout do desafio: sempre recusa.'
                 )
             ),
 

--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Donate link: https://www.linknacional.com/wordpress/plugins/
 Tags: rede, PIX, cartao credito, itau, pagamento  
 Requires at least: 6.0
 Tested up to: 7.1  
-Stable tag: 5.4.9
+Stable tag: 5.4.10
 Requires PHP: 8.2
 License: GPLv3 or later  
 License URI: http://www.gnu.org/licenses/gpl-3.0.txt
@@ -124,6 +124,11 @@ A: Yes — tested up to WordPress 6.8.
 ---
 
 ## Changelog
+
+### 5.4.10 - 2026-08-26
+* Fix: 3D Secure challenge cancellation/timeout now declines the transaction (onFailure always "decline").
+* Adjustment: Cards not enrolled in 3D Secure (returnCode 204) are retried without 3DS when "Continue without 3DS" is enabled.
+* Fix: 3DS webhook security validation failure now redirects to checkout and adds an order note.
 
 ### 5.4.9 - 2026-08-17
 * Tweak: Webhook route validation.
@@ -285,6 +290,11 @@ A: Yes — tested up to WordPress 6.8.
 ---
 
 ## Upgrade Notice
+
+### 5.4.10 - 2026-08-26
+* Fix: 3D Secure challenge cancellation/timeout now declines the transaction (onFailure always "decline").
+* Adjustment: Cards not enrolled in 3D Secure (returnCode 204) are retried without 3DS when "Continue without 3DS" is enabled.
+* Fix: 3DS webhook security validation failure now redirects to checkout and adds an order note.
 
 ### 5.4.9 - 2026-08-17
 * Tweak: Webhook route validation.

--- a/integration-rede-for-woocommerce.php
+++ b/integration-rede-for-woocommerce.php
@@ -15,7 +15,7 @@
  * @wordpress-plugin
  * Plugin Name:       Integration Rede Itaú for WooCommerce — Payment PIX, Credit Card and Debit
  * Description:       Receba pagamentos por meio de cartões de crédito e débito, de diferentes bandeiras, usando a tecnologia de autenticação 3DS e recursos avançados de proteção contra fraudes.
- * Version:           5.4.9
+ * Version:           5.4.10
  * Requires at least: 6.0
  * Requires PHP:      8.2
  * Author:            Link Nacional

--- a/lkn-integration-rede-for-woocommerce-file.php
+++ b/lkn-integration-rede-for-woocommerce-file.php
@@ -17,7 +17,7 @@ require_once __DIR__ . '/vendor/autoload.php';
  * Rename this for your plugin and update it as you release new versions.
  */
 if (! defined('INTEGRATION_REDE_FOR_WOOCOMMERCE_VERSION')) {
-    define('INTEGRATION_REDE_FOR_WOOCOMMERCE_VERSION', '5.4.9');
+    define('INTEGRATION_REDE_FOR_WOOCOMMERCE_VERSION', '5.4.10');
 }
 
 if (! defined('LKN_WC_REDE_WPP_NUMBER')) {


### PR DESCRIPTION
# Integration Rede for WooCommerce

Contribuidores: linknacional

Link: https://www.linknacional.com.br/wordpress/

Tags: woocommerce, pagamento, rede, maxipago, credit, debit, pix, gateway

Testado até: 7.0

Versão estável: 5.4.10

Licença: GPLv2 ou posterior

URI da Licença: https://opensource.org/licenses/MIT

Traduções: Português(Brasil) / Inglês

Integre pagamentos via Rede e Maxipago à sua loja WooCommerce com suporte completo a cartão de crédito, débito e PIX.

## Descrição

O Integration Rede for WooCommerce oferece integração completa com os gateways de pagamento Rede e Maxipago, permitindo que sua loja WooCommerce aceite pagamentos via:

- **Cartão de Crédito** (Rede e Maxipago)
- **Cartão de Débito** (Rede e Maxipago)  
- **PIX** (Rede)

A [Rede](https://www.userede.com.br) é uma das principais adquirentes do Brasil, oferecendo soluções seguras e confiáveis para processamento de pagamentos. O [Maxipago](https://www.maxipago.com) é uma plataforma robusta de gateway de pagamentos com ampla cobertura internacional.

**Recursos Principais**

- Sistema de parcelamento inteligente com cálculo de juros
- Validação 3DS para débito Maxipago
- Cartão animado no checkout
- Sistema de cron para verificação automática de PIX
- Compatibilidade com checkout por shortcode
- Suporte a reembolsos automáticos
- Logs detalhados de transações
- Conversão de moeda
- Compatibilidade com editor de blocos WooCommerce

**Dependências**

Este plugin depende do WooCommerce. Certifique-se de que o WooCommerce está instalado e configurado antes de instalar o Integration Rede for WooCommerce.

**Instruções de uso**

1. Procure na barra lateral do WordPress por 'Integration Rede for WooCommerce'.
2. Nas opções do WooCommerce, acesse 'Pagamentos' e configure os gateways disponíveis: 'Rede Credit', 'Rede Debit', 'Rede PIX', 'Maxipago Credit', 'Maxipago Debit'.
3. Configure as credenciais de API necessárias para cada gateway.
4. Defina as opções de parcelamento, juros e limites conforme necessário.
5. Salve as configurações.

Pronto! Seus clientes poderão pagar via Rede e Maxipago com múltiplos métodos de pagamento.

## Instalação

1. Baixe o plugin.
2. No painel administrativo do WordPress, vá para Plugins > Adicionar Novo.
3. Clique em "Enviar Plugin" e selecione o arquivo ZIP do plugin que você baixou.
4. Clique em "Instalar Agora" e, em seguida, em "Ativar Plugin".
5. Certifique-se de que o plugin WooCommerce também está ativado.

## CHANGELOG:

* Ajuste: Cancelamento ou timeout no desafio 3D Secure agora recusa a transação (onFailure sempre "decline").
* Ajuste: Cartões não registrados no 3DS (returnCode 204) são reenviados sem 3DS quando "Continuar sem 3DS" está habilitado.
* Correção: Falha na validação de segurança do webhook 3DS agora redireciona ao checkout e registra nota no pedido.